### PR TITLE
Use pragma once for headers

### DIFF
--- a/include/two_point_interpolation/constant_acc.hpp
+++ b/include/two_point_interpolation/constant_acc.hpp
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
+#pragma once
+
+#include <algorithm>
 #include <cmath>
-#include <vector>
+#include <iostream>
 #include <stdexcept>
+#include <vector>
 
 inline double vInteg(const double v0, const double a, const double dt) {
     return v0 + a * dt;

--- a/include/two_point_interpolation/constant_jerk.hpp
+++ b/include/two_point_interpolation/constant_jerk.hpp
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
+#pragma once
+
 #include <cmath>
-#include <vector>
+#include <iostream>
 #include <stdexcept>
+#include <vector>
 
 /**
  * Two-point interpolation with constant jerk constraints.
@@ -311,3 +313,4 @@ public:
         return {p, v, a, j};
     }
 };
+


### PR DESCRIPTION
## Summary
- switch the constant acceleration and jerk headers back to `#pragma once` so they align with the rest of the project and remain safe for multiple inclusion

## Testing
- ./build_and_test.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691891cd854c832e8c57eba71fd9e5fb)